### PR TITLE
Add Windows ARM binary builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,7 @@ jobs:
               linux_targets+=("ubuntu-latest|x64")
               macos_versions='["macos-15","macos-15-intel"]'
               windows_targets+=("windows-latest|x64")
+              windows_targets+=("windows-11-arm|arm64")
               ;;
             linux-x64)
               run_linux=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,18 +388,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Set up MSYS2 toolchain
-        id: msys2
-        uses: msys2/setup-msys2@cafece8e6baf9247cf9b1bf95097b0b983cc558d # v2.31.0
-        with:
-          msystem: ${{ matrix.arch == 'arm64' && 'CLANGARM64' || 'UCRT64' }}
-          path-type: inherit
-          update: true
-          pacboy: >-
-            toolchain:p
-            cmake:p
-            ninja:p
-
       - name: Create venv
         shell: pwsh
         run: |
@@ -412,47 +400,45 @@ jobs:
           $pythonExe = Join-Path $env:VIRTUAL_ENV "Scripts\python.exe"
           & $pythonExe -m pip install --upgrade build wheel
 
-          $msys2Root = "${{ steps.msys2.outputs.msys2-location }}"
-          if ("${{ matrix.arch }}" -eq "arm64") {
-            $toolPrefix = "clangarm64"
-            $ccName = "clang.exe"
-            $cxxName = "clang++.exe"
-          } else {
-            $toolPrefix = "ucrt64"
-            $ccName = "gcc.exe"
-            $cxxName = "g++.exe"
+          $targetArch = if ("${{ matrix.arch }}" -eq "arm64") { "arm64" } else { "x64" }
+          $hostArch = $targetArch
+          $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+          if (-not (Test-Path $vswhere)) {
+            throw "vswhere.exe not found at $vswhere"
           }
 
-          $toolBin = Join-Path $msys2Root "$toolPrefix\bin"
-          $cc = Join-Path $toolBin $ccName
-          $cxx = Join-Path $toolBin $cxxName
-          $ninja = Join-Path $toolBin "ninja.exe"
-          $cmake = Join-Path $toolBin "cmake.exe"
-
-          if (-not (Test-Path $cc) -or -not (Test-Path $cxx) -or -not (Test-Path $ninja) -or -not (Test-Path $cmake)) {
-            throw "Could not locate compiler/ninja/cmake in MSYS2: $toolBin"
+          $vsInstallPath = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          if (-not $vsInstallPath) {
+            throw "Could not locate a Visual Studio installation with C++ tools"
           }
 
-          $env:PATH = "$toolBin;$env:PATH"
+          $vsDevCmd = Join-Path $vsInstallPath "Common7\Tools\VsDevCmd.bat"
+          if (-not (Test-Path $vsDevCmd)) {
+            throw "VsDevCmd.bat not found at $vsDevCmd"
+          }
 
-          $env:CMAKE_GENERATOR = "Ninja"
-          $env:CC = $cc
-          $env:CXX = $cxx
+          # Import Visual Studio developer environment vars into this PowerShell step.
+          $envDump = & cmd.exe /s /c "`"$vsDevCmd`" -no_logo -host_arch=$hostArch -arch=$targetArch && set"
+          foreach ($line in $envDump) {
+            if ($line -match '^(.*?)=(.*)$') {
+              Set-Item -Path ("Env:" + $matches[1]) -Value $matches[2]
+            }
+          }
+
+          $clCmd = Get-Command cl.exe -ErrorAction SilentlyContinue
+          $cmakeCmd = Get-Command cmake.exe -ErrorAction SilentlyContinue
+          if (-not $clCmd -or -not $cmakeCmd) {
+            throw "MSVC or CMake not available in PATH after loading VsDevCmd"
+          }
+
+          $env:CMAKE_GENERATOR = "Visual Studio 17 2022"
+          $env:CMAKE_GENERATOR_PLATFORM = $targetArch
           Remove-Item Env:CMAKE_ARGS -ErrorAction SilentlyContinue
 
-          if ("${{ matrix.arch }}" -eq "arm64") {
-            Write-Host "Using clang: $cc"
-            Write-Host "Using clang++: $cxx"
-          } else {
-            Write-Host "Using gcc: $cc"
-            Write-Host "Using g++: $cxx"
-          }
-          Write-Host "Using ninja: $ninja"
-          Write-Host "Using cmake: $cmake"
-          & $cc --version
-          & $cxx --version
-          & $cmake --version
-          & $ninja --version
+          Write-Host "Using cl: $($clCmd.Source)"
+          Write-Host "Using cmake: $($cmakeCmd.Source)"
+          & cmd.exe /c "cl"
+          & $cmakeCmd.Source --version
           & $pythonExe -m build --wheel -o dist
 
       - name: Install wheel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,6 +389,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up MSYS2 toolchain
+        id: msys2
         uses: msys2/setup-msys2@cafece8e6baf9247cf9b1bf95097b0b983cc558d # v2.31.0
         with:
           msystem: ${{ matrix.arch == 'arm64' && 'CLANGARM64' || 'UCRT64' }}
@@ -410,59 +411,33 @@ jobs:
           .\env\Scripts\Activate.ps1
           pip install --upgrade build wheel
 
+          $msys2Root = "${{ steps.msys2.outputs.msys2-location }}"
           if ("${{ matrix.arch }}" -eq "arm64") {
-            $ccCandidates = @(Get-Command clang.exe -All -ErrorAction Stop | Select-Object -ExpandProperty Source)
-            $cxxCandidates = @(Get-Command clang++.exe -All -ErrorAction Stop | Select-Object -ExpandProperty Source)
-            $toolPattern = '[\\/](clangarm64|clang64)[\\/]bin[\\/]'
+            $toolPrefix = "clangarm64"
+            $ccName = "clang.exe"
+            $cxxName = "clang++.exe"
           } else {
-            $ccCandidates = @(Get-Command gcc.exe -All -ErrorAction Stop | Select-Object -ExpandProperty Source)
-            $cxxCandidates = @(Get-Command g++.exe -All -ErrorAction Stop | Select-Object -ExpandProperty Source)
-            $toolPattern = '[\\/](ucrt64|mingw64)[\\/]bin[\\/]'
+            $toolPrefix = "ucrt64"
+            $ccName = "gcc.exe"
+            $cxxName = "g++.exe"
           }
 
-          $ninjaCandidates = @(Get-Command ninja.exe -All -ErrorAction Stop | Select-Object -ExpandProperty Source)
-          $cmakeCandidates = @(Get-Command cmake.exe -All -ErrorAction Stop | Select-Object -ExpandProperty Source)
+          $toolBin = Join-Path $msys2Root "$toolPrefix\bin"
+          $cc = Join-Path $toolBin $ccName
+          $cxx = Join-Path $toolBin $cxxName
+          $ninja = Join-Path $toolBin "ninja.exe"
+          $cmake = Join-Path $toolBin "cmake.exe"
 
-          if ("${{ matrix.arch }}" -eq "arm64") {
-            Write-Host "clang candidates: $($ccCandidates -join '; ')"
-            Write-Host "clang++ candidates: $($cxxCandidates -join '; ')"
-          } else {
-            Write-Host "gcc candidates: $($ccCandidates -join '; ')"
-            Write-Host "g++ candidates: $($cxxCandidates -join '; ')"
-          }
-          Write-Host "ninja candidates: $($ninjaCandidates -join '; ')"
-          Write-Host "cmake candidates: $($cmakeCandidates -join '; ')"
-
-          $cc = $ccCandidates | Where-Object { $_ -match $toolPattern } | Select-Object -First 1
-          if (-not $cc) { $cc = $ccCandidates | Where-Object { $_ -match '(msys|mingw|ucrt|clang)' } | Select-Object -First 1 }
-          if (-not $cc) { $cc = $ccCandidates | Select-Object -First 1 }
-
-          $cxx = $cxxCandidates | Where-Object { $_ -match $toolPattern } | Select-Object -First 1
-          if (-not $cxx) { $cxx = $cxxCandidates | Where-Object { $_ -match '(msys|mingw|ucrt|clang)' } | Select-Object -First 1 }
-          if (-not $cxx) { $cxx = $cxxCandidates | Select-Object -First 1 }
-
-          $ninja = $ninjaCandidates | Where-Object { $_ -match $toolPattern } | Select-Object -First 1
-          if (-not $ninja) { $ninja = $ninjaCandidates | Where-Object { $_ -match '(msys|mingw|ucrt|clang)' } | Select-Object -First 1 }
-          if (-not $ninja) { $ninja = $ninjaCandidates | Select-Object -First 1 }
-
-          $cmake = $cmakeCandidates | Where-Object { $_ -match $toolPattern } | Select-Object -First 1
-          if (-not $cmake) { $cmake = $cmakeCandidates | Where-Object { $_ -match '(msys|mingw|ucrt|clang)' } | Select-Object -First 1 }
-          if (-not $cmake) { $cmake = $cmakeCandidates | Select-Object -First 1 }
-
-          if (-not $cc -or -not $cxx -or -not $ninja -or -not $cmake) {
-            throw "Could not locate compiler/ninja/cmake in PATH"
+          if (-not (Test-Path $cc) -or -not (Test-Path $cxx) -or -not (Test-Path $ninja) -or -not (Test-Path $cmake)) {
+            throw "Could not locate compiler/ninja/cmake in MSYS2: $toolBin"
           }
 
-          $toolBin = Split-Path -Parent $cc
           $env:PATH = "$toolBin;$env:PATH"
-
-          $ccForCmake = $cc -replace '\\', '/'
-          $cxxForCmake = $cxx -replace '\\', '/'
 
           $env:CMAKE_GENERATOR = "Ninja"
           $env:CC = $cc
           $env:CXX = $cxx
-          $env:CMAKE_ARGS = "-DCMAKE_C_COMPILER:FILEPATH=$ccForCmake -DCMAKE_CXX_COMPILER:FILEPATH=$cxxForCmake"
+          Remove-Item Env:CMAKE_ARGS -ErrorAction SilentlyContinue
 
           if ("${{ matrix.arch }}" -eq "arm64") {
             Write-Host "Using clang: $cc"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,16 +103,6 @@ jobs:
           macos_versions='[]'
           windows_targets=()
 
-          # If target is windows-arm64, filter out 3.10 from py_versions
-          if [[ "$target" == "windows-arm64" ]]; then
-            filtered_py_versions=()
-            for py in "${py_versions[@]}"; do
-              if [[ "$py" != "3.10" ]]; then
-                filtered_py_versions+=("$py")
-              fi
-            done
-            py_versions=("${filtered_py_versions[@]}")
-          fi
 
           case "$target" in
             all)
@@ -154,6 +144,7 @@ jobs:
               ;;
           esac
 
+
           build_include_matrix() {
             local -n target_ref=$1
             local matrix='{"include":['
@@ -162,7 +153,17 @@ jobs:
             for target_item in "${target_ref[@]}"; do
               local runs_on="${target_item%%|*}"
               local arch="${target_item##*|}"
-              for py in "${py_versions[@]}"; do
+              local py_list=("${py_versions[@]}")
+              # Special case: skip 3.10 for windows-11-arm|arm64
+              if [[ "$runs_on" == "windows-11-arm" && "$arch" == "arm64" ]]; then
+                py_list=()
+                for py in "${py_versions[@]}"; do
+                  if [[ "$py" != "3.10" ]]; then
+                    py_list+=("$py")
+                  fi
+                done
+              fi
+              for py in "${py_list[@]}"; do
                 if [[ "$first_item" == true ]]; then
                   first_item=false
                 else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,7 +273,9 @@ jobs:
         if: matrix.python-version != '3.14'
         run: |
           source env/bin/activate
+          cd tests
           python -c "import JupiterMag; print(JupiterMag.__version__)"
+          if [ $? -ne 0 ]; then exit 1; fi
 
       - name: Upload wheel artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -361,7 +363,9 @@ jobs:
         if: matrix.python-version != '3.14'
         run: |
           source env/bin/activate
+          cd tests
           python -c "import JupiterMag; print(JupiterMag.__version__)"
+          if [ $? -ne 0 ]; then exit 1; fi
 
       - name: Upload wheel artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -467,7 +471,9 @@ jobs:
         shell: pwsh
         run: |
           .\env\Scripts\Activate.ps1
+          cd tests
           python -c "import JupiterMag; print(JupiterMag.__version__)"
+          if ($LASTEXITCODE -ne 0) { exit 1 }
 
       - name: Upload wheel artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,17 @@ jobs:
           macos_versions='[]'
           windows_targets=()
 
+           # If target is windows-arm64, filter out 3.10 from py_versions
+            if [[ "$target" == "windows-arm64" ]]; then
+              filtered_py_versions=()
+              for py in "${py_versions[@]}"; do
+                if [[ "$py" != "3.10" ]]; then
+                  filtered_py_versions+=("$py")
+                fi
+              done
+              py_versions=("${filtered_py_versions[@]}")
+            fi
+
           case "$target" in
             all)
               run_linux=true
@@ -132,10 +143,10 @@ jobs:
               run_windows=true
               windows_targets+=("windows-latest|x64")
               ;;
-            windows-arm64)
-              run_windows=true
-              windows_targets+=("windows-11-arm|arm64")
-              ;;
+              windows-arm64)
+                run_windows=true
+                windows_targets+=("windows-11-arm|arm64")
+                ;;
             *)
               echo "Unsupported target: $target"
               exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,16 +103,16 @@ jobs:
           macos_versions='[]'
           windows_targets=()
 
-           # If target is windows-arm64, filter out 3.10 from py_versions
-            if [[ "$target" == "windows-arm64" ]]; then
-              filtered_py_versions=()
-              for py in "${py_versions[@]}"; do
-                if [[ "$py" != "3.10" ]]; then
-                  filtered_py_versions+=("$py")
-                fi
-              done
-              py_versions=("${filtered_py_versions[@]}")
-            fi
+          # If target is windows-arm64, filter out 3.10 from py_versions
+          if [[ "$target" == "windows-arm64" ]]; then
+            filtered_py_versions=()
+            for py in "${py_versions[@]}"; do
+              if [[ "$py" != "3.10" ]]; then
+                filtered_py_versions+=("$py")
+              fi
+            done
+            py_versions=("${filtered_py_versions[@]}")
+          fi
 
           case "$target" in
             all)
@@ -143,10 +143,10 @@ jobs:
               run_windows=true
               windows_targets+=("windows-latest|x64")
               ;;
-              windows-arm64)
-                run_windows=true
-                windows_targets+=("windows-11-arm|arm64")
-                ;;
+            windows-arm64)
+              run_windows=true
+              windows_targets+=("windows-11-arm|arm64")
+              ;;
             *)
               echo "Unsupported target: $target"
               exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,7 +409,8 @@ jobs:
         shell: pwsh
         run: |
           .\env\Scripts\Activate.ps1
-          pip install --upgrade build wheel
+          $pythonExe = Join-Path $env:VIRTUAL_ENV "Scripts\python.exe"
+          & $pythonExe -m pip install --upgrade build wheel
 
           $msys2Root = "${{ steps.msys2.outputs.msys2-location }}"
           if ("${{ matrix.arch }}" -eq "arm64") {
@@ -452,7 +453,7 @@ jobs:
           & $cxx --version
           & $cmake --version
           & $ninja --version
-          python -m build --wheel -o dist
+          & $pythonExe -m build --wheel -o dist
 
       - name: Install wheel
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,16 +389,15 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up MSYS2 toolchain
-        if: matrix.arch == 'x64'
         uses: msys2/setup-msys2@cafece8e6baf9247cf9b1bf95097b0b983cc558d # v2.31.0
         with:
-          msystem: UCRT64
+          msystem: ${{ matrix.arch == 'arm64' && 'CLANGARM64' || 'UCRT64' }}
           path-type: inherit
           update: true
-          install: >-
-            mingw-w64-ucrt-x86_64-gcc
-            mingw-w64-ucrt-x86_64-cmake
-            mingw-w64-ucrt-x86_64-ninja
+          pacboy: >-
+            toolchain:p
+            cmake:p
+            ninja:p
 
       - name: Create venv
         shell: pwsh
@@ -412,62 +411,70 @@ jobs:
           pip install --upgrade build wheel
 
           if ("${{ matrix.arch }}" -eq "arm64") {
-            # Use the default ARM64 MSVC toolchain on Windows ARM runners.
-            Remove-Item Env:CMAKE_GENERATOR -ErrorAction SilentlyContinue
-            Remove-Item Env:CC -ErrorAction SilentlyContinue
-            Remove-Item Env:CXX -ErrorAction SilentlyContinue
-            Remove-Item Env:CMAKE_ARGS -ErrorAction SilentlyContinue
-            python -m build --wheel -o dist
-            exit 0
+            $ccCandidates = @(Get-Command clang.exe -All -ErrorAction Stop | Select-Object -ExpandProperty Source)
+            $cxxCandidates = @(Get-Command clang++.exe -All -ErrorAction Stop | Select-Object -ExpandProperty Source)
+            $toolPattern = '[\\/](clangarm64|clang64)[\\/]bin[\\/]'
+          } else {
+            $ccCandidates = @(Get-Command gcc.exe -All -ErrorAction Stop | Select-Object -ExpandProperty Source)
+            $cxxCandidates = @(Get-Command g++.exe -All -ErrorAction Stop | Select-Object -ExpandProperty Source)
+            $toolPattern = '[\\/](ucrt64|mingw64)[\\/]bin[\\/]'
           }
 
-          $gccCandidates = @(Get-Command gcc.exe -All -ErrorAction Stop | Select-Object -ExpandProperty Source)
-          $gxxCandidates = @(Get-Command g++.exe -All -ErrorAction Stop | Select-Object -ExpandProperty Source)
           $ninjaCandidates = @(Get-Command ninja.exe -All -ErrorAction Stop | Select-Object -ExpandProperty Source)
           $cmakeCandidates = @(Get-Command cmake.exe -All -ErrorAction Stop | Select-Object -ExpandProperty Source)
 
-          Write-Host "gcc candidates: $($gccCandidates -join '; ')"
-          Write-Host "g++ candidates: $($gxxCandidates -join '; ')"
+          if ("${{ matrix.arch }}" -eq "arm64") {
+            Write-Host "clang candidates: $($ccCandidates -join '; ')"
+            Write-Host "clang++ candidates: $($cxxCandidates -join '; ')"
+          } else {
+            Write-Host "gcc candidates: $($ccCandidates -join '; ')"
+            Write-Host "g++ candidates: $($cxxCandidates -join '; ')"
+          }
           Write-Host "ninja candidates: $($ninjaCandidates -join '; ')"
           Write-Host "cmake candidates: $($cmakeCandidates -join '; ')"
 
-          $gcc = $gccCandidates | Where-Object { $_ -match '[\\/](ucrt64|mingw64)[\\/]bin[\\/]' } | Select-Object -First 1
-          if (-not $gcc) { $gcc = $gccCandidates | Where-Object { $_ -match '(msys|mingw|ucrt)' } | Select-Object -First 1 }
-          if (-not $gcc) { $gcc = $gccCandidates | Select-Object -First 1 }
+          $cc = $ccCandidates | Where-Object { $_ -match $toolPattern } | Select-Object -First 1
+          if (-not $cc) { $cc = $ccCandidates | Where-Object { $_ -match '(msys|mingw|ucrt|clang)' } | Select-Object -First 1 }
+          if (-not $cc) { $cc = $ccCandidates | Select-Object -First 1 }
 
-          $gxx = $gxxCandidates | Where-Object { $_ -match '[\\/](ucrt64|mingw64)[\\/]bin[\\/]' } | Select-Object -First 1
-          if (-not $gxx) { $gxx = $gxxCandidates | Where-Object { $_ -match '(msys|mingw|ucrt)' } | Select-Object -First 1 }
-          if (-not $gxx) { $gxx = $gxxCandidates | Select-Object -First 1 }
+          $cxx = $cxxCandidates | Where-Object { $_ -match $toolPattern } | Select-Object -First 1
+          if (-not $cxx) { $cxx = $cxxCandidates | Where-Object { $_ -match '(msys|mingw|ucrt|clang)' } | Select-Object -First 1 }
+          if (-not $cxx) { $cxx = $cxxCandidates | Select-Object -First 1 }
 
-          $ninja = $ninjaCandidates | Where-Object { $_ -match '[\\/](ucrt64|mingw64)[\\/]bin[\\/]' } | Select-Object -First 1
-          if (-not $ninja) { $ninja = $ninjaCandidates | Where-Object { $_ -match '(msys|mingw|ucrt)' } | Select-Object -First 1 }
+          $ninja = $ninjaCandidates | Where-Object { $_ -match $toolPattern } | Select-Object -First 1
+          if (-not $ninja) { $ninja = $ninjaCandidates | Where-Object { $_ -match '(msys|mingw|ucrt|clang)' } | Select-Object -First 1 }
           if (-not $ninja) { $ninja = $ninjaCandidates | Select-Object -First 1 }
 
-          $cmake = $cmakeCandidates | Where-Object { $_ -match '[\\/](ucrt64|mingw64)[\\/]bin[\\/]' } | Select-Object -First 1
-          if (-not $cmake) { $cmake = $cmakeCandidates | Where-Object { $_ -match '(msys|mingw|ucrt)' } | Select-Object -First 1 }
+          $cmake = $cmakeCandidates | Where-Object { $_ -match $toolPattern } | Select-Object -First 1
+          if (-not $cmake) { $cmake = $cmakeCandidates | Where-Object { $_ -match '(msys|mingw|ucrt|clang)' } | Select-Object -First 1 }
           if (-not $cmake) { $cmake = $cmakeCandidates | Select-Object -First 1 }
 
-          if (-not $gcc -or -not $gxx -or -not $ninja -or -not $cmake) {
-            throw "Could not locate gcc/g++/ninja/cmake in PATH"
+          if (-not $cc -or -not $cxx -or -not $ninja -or -not $cmake) {
+            throw "Could not locate compiler/ninja/cmake in PATH"
           }
 
-          $toolBin = Split-Path -Parent $gcc
+          $toolBin = Split-Path -Parent $cc
           $env:PATH = "$toolBin;$env:PATH"
 
-          $gccForCmake = $gcc -replace '\\', '/'
-          $gxxForCmake = $gxx -replace '\\', '/'
+          $ccForCmake = $cc -replace '\\', '/'
+          $cxxForCmake = $cxx -replace '\\', '/'
 
           $env:CMAKE_GENERATOR = "Ninja"
-          $env:CC = $gcc
-          $env:CXX = $gxx
-          $env:CMAKE_ARGS = "-DCMAKE_C_COMPILER:FILEPATH=$gccForCmake -DCMAKE_CXX_COMPILER:FILEPATH=$gxxForCmake"
+          $env:CC = $cc
+          $env:CXX = $cxx
+          $env:CMAKE_ARGS = "-DCMAKE_C_COMPILER:FILEPATH=$ccForCmake -DCMAKE_CXX_COMPILER:FILEPATH=$cxxForCmake"
 
-          Write-Host "Using gcc: $gcc"
-          Write-Host "Using g++: $gxx"
+          if ("${{ matrix.arch }}" -eq "arm64") {
+            Write-Host "Using clang: $cc"
+            Write-Host "Using clang++: $cxx"
+          } else {
+            Write-Host "Using gcc: $cc"
+            Write-Host "Using g++: $cxx"
+          }
           Write-Host "Using ninja: $ninja"
           Write-Host "Using cmake: $cmake"
-          & $gcc --version
-          & $gxx --version
+          & $cc --version
+          & $cxx --version
           & $cmake --version
           & $ninja --version
           python -m build --wheel -o dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,17 +2,202 @@ name: CI
 
 on:
   workflow_dispatch:
+    inputs:
+      target:
+        description: OS and architecture target
+        required: false
+        type: choice
+        default: all
+        options:
+          - all
+          - linux-x64
+          - linux-arm64
+          - macos-arm64
+          - macos-x64
+          - windows-x64
+          - windows-arm64
+      python_version:
+        description: Python version
+        required: false
+        type: choice
+        default: all
+        options:
+          - all
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
   workflow_call:
+    inputs:
+      target:
+        description: OS and architecture target (all, linux-x64, linux-arm64, macos-arm64, macos-x64, windows-x64, windows-arm64)
+        required: false
+        type: string
+        default: all
+      python_version:
+        description: Python version (all, 3.10, 3.11, 3.12, 3.13, 3.14)
+        required: false
+        type: string
+        default: all
   pull_request:
     branches: [main]
 
 jobs:
-  build-linux:
+  setup:
     runs-on: ubuntu-latest
+    outputs:
+      run_linux: ${{ steps.resolve.outputs.run_linux }}
+      run_macos: ${{ steps.resolve.outputs.run_macos }}
+      run_windows: ${{ steps.resolve.outputs.run_windows }}
+      linux_matrix: ${{ steps.resolve.outputs.linux_matrix }}
+      macos_matrix: ${{ steps.resolve.outputs.macos_matrix }}
+      windows_matrix: ${{ steps.resolve.outputs.windows_matrix }}
+    steps:
+      - name: Resolve selected targets and matrix values
+        id: resolve
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TARGET_INPUT: ${{ inputs.target || 'all' }}
+          PYTHON_INPUT: ${{ inputs.python_version || 'all' }}
+        run: |
+          set -euo pipefail
+
+          target="$TARGET_INPUT"
+          python_version="$PYTHON_INPUT"
+
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            target="all"
+            python_version="all"
+          fi
+
+          case "$python_version" in
+            all)
+              py_versions=("3.10" "3.11" "3.12" "3.13" "3.14")
+              ;;
+            3.10|3.11|3.12|3.13|3.14)
+              py_versions=("$python_version")
+              ;;
+            *)
+              echo "Unsupported python_version: $python_version"
+              exit 1
+              ;;
+          esac
+
+          python_json='['
+          first=true
+          for py in "${py_versions[@]}"; do
+            if [[ "$first" == true ]]; then
+              first=false
+            else
+              python_json+=','
+            fi
+            python_json+="\"$py\""
+          done
+          python_json+=']'
+
+          run_linux=false
+          run_macos=false
+          run_windows=false
+          linux_targets=()
+          macos_versions='[]'
+          windows_targets=()
+
+          case "$target" in
+            all)
+              run_linux=true
+              run_macos=true
+              run_windows=true
+              linux_targets+=("ubuntu-latest|x64")
+              macos_versions='["macos-15","macos-15-intel"]'
+              windows_targets+=("windows-latest|x64")
+              ;;
+            linux-x64)
+              run_linux=true
+              linux_targets+=("ubuntu-latest|x64")
+              ;;
+            linux-arm64)
+              run_linux=true
+              linux_targets+=("ubuntu-24.04-arm|arm64")
+              ;;
+            macos-arm64)
+              run_macos=true
+              macos_versions='["macos-15"]'
+              ;;
+            macos-x64)
+              run_macos=true
+              macos_versions='["macos-15-intel"]'
+              ;;
+            windows-x64)
+              run_windows=true
+              windows_targets+=("windows-latest|x64")
+              ;;
+            windows-arm64)
+              run_windows=true
+              windows_targets+=("windows-11-arm|arm64")
+              ;;
+            *)
+              echo "Unsupported target: $target"
+              exit 1
+              ;;
+          esac
+
+          build_include_matrix() {
+            local -n target_ref=$1
+            local matrix='{"include":['
+            local first_item=true
+
+            for target_item in "${target_ref[@]}"; do
+              local runs_on="${target_item%%|*}"
+              local arch="${target_item##*|}"
+              for py in "${py_versions[@]}"; do
+                if [[ "$first_item" == true ]]; then
+                  first_item=false
+                else
+                  matrix+=','
+                fi
+                matrix+="{\"runs-on\":\"$runs_on\",\"arch\":\"$arch\",\"python-version\":\"$py\"}"
+              done
+            done
+
+            matrix+=']}'
+            echo "$matrix"
+          }
+
+          if [[ "$run_linux" == "true" ]]; then
+            linux_matrix="$(build_include_matrix linux_targets)"
+          else
+            linux_matrix='{"include":[]}'
+          fi
+
+          if [[ "$run_macos" == "true" ]]; then
+            macos_matrix="{\"macos-version\":$macos_versions,\"python-version\":$python_json}"
+          else
+            macos_matrix='{"macos-version":[],"python-version":[]}'
+          fi
+
+          if [[ "$run_windows" == "true" ]]; then
+            windows_matrix="$(build_include_matrix windows_targets)"
+          else
+            windows_matrix='{"include":[]}'
+          fi
+
+          {
+            echo "run_linux=$run_linux"
+            echo "run_macos=$run_macos"
+            echo "run_windows=$run_windows"
+            echo "linux_matrix=$linux_matrix"
+            echo "macos_matrix=$macos_matrix"
+            echo "windows_matrix=$windows_matrix"
+          } >> "$GITHUB_OUTPUT"
+
+  build-linux:
+    needs: setup
+    if: ${{ needs.setup.outputs.run_linux == 'true' }}
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
-      matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+      matrix: ${{ fromJson(needs.setup.outputs.linux_matrix) }}
 
     steps:
       - name: Checkout repository
@@ -43,11 +228,18 @@ jobs:
         run: |
           rm -rf dist wheelhouse
           mkdir -p dist wheelhouse
+
+          if [[ "${{ matrix.arch }}" == "arm64" ]]; then
+            MANYLINUX_IMAGE="quay.io/pypa/manylinux_2_34_aarch64:latest"
+          else
+            MANYLINUX_IMAGE="quay.io/pypa/manylinux_2_34:latest"
+          fi
+
           docker run --rm \
             -e PYTAG="${MANYLINUX_PYTAG}" \
             -v "${{ github.workspace }}:/io" \
             -w /io \
-            quay.io/pypa/manylinux_2_34:latest \
+            "$MANYLINUX_IMAGE" \
             /bin/bash -lc '
               set -euo pipefail
               if ! command -v cmake >/dev/null 2>&1; then
@@ -73,7 +265,7 @@ jobs:
       - name: Upload wheel artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: wheels-linux-py${{ matrix.python-version }}
+          name: wheels-linux-${{ matrix.arch }}-py${{ matrix.python-version }}
           path: wheelhouse/*.whl
 
       - name: Build sdist (Linux 3.14)
@@ -94,7 +286,7 @@ jobs:
         if: matrix.python-version == '3.14'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: sdist-linux-py${{ matrix.python-version }}
+          name: sdist-linux-${{ matrix.arch }}-py${{ matrix.python-version }}
           path: dist/*.tar.gz
 
       - name: Run pytest from tests directory
@@ -106,12 +298,12 @@ jobs:
           pytest -q
 
   build-macos:
+    needs: setup
+    if: ${{ needs.setup.outputs.run_macos == 'true' }}
     runs-on: ${{ matrix.macos-version }}
     strategy:
       fail-fast: false
-      matrix:
-        macos-version: ["macos-15", "macos-15-intel"]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+      matrix: ${{ fromJson(needs.setup.outputs.macos_matrix) }}
 
     steps:
       - name: Checkout repository
@@ -178,11 +370,12 @@ jobs:
           pytest -q
 
   build-windows:
-    runs-on: windows-latest
+    needs: setup
+    if: ${{ needs.setup.outputs.run_windows == 'true' }}
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
-      matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+      matrix: ${{ fromJson(needs.setup.outputs.windows_matrix) }}
 
     steps:
       - name: Checkout repository
@@ -196,6 +389,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up MSYS2 toolchain
+        if: matrix.arch == 'x64'
         uses: msys2/setup-msys2@cafece8e6baf9247cf9b1bf95097b0b983cc558d # v2.31.0
         with:
           msystem: UCRT64
@@ -216,6 +410,17 @@ jobs:
         run: |
           .\env\Scripts\Activate.ps1
           pip install --upgrade build wheel
+
+          if ("${{ matrix.arch }}" -eq "arm64") {
+            # Use the default ARM64 MSVC toolchain on Windows ARM runners.
+            Remove-Item Env:CMAKE_GENERATOR -ErrorAction SilentlyContinue
+            Remove-Item Env:CC -ErrorAction SilentlyContinue
+            Remove-Item Env:CXX -ErrorAction SilentlyContinue
+            Remove-Item Env:CMAKE_ARGS -ErrorAction SilentlyContinue
+            python -m build --wheel -o dist
+            exit 0
+          }
+
           $gccCandidates = @(Get-Command gcc.exe -All -ErrorAction Stop | Select-Object -ExpandProperty Source)
           $gxxCandidates = @(Get-Command g++.exe -All -ErrorAction Stop | Select-Object -ExpandProperty Source)
           $ninjaCandidates = @(Get-Command ninja.exe -All -ErrorAction Stop | Select-Object -ExpandProperty Source)
@@ -285,7 +490,7 @@ jobs:
       - name: Upload wheel artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: wheels-windows-py${{ matrix.python-version }}
+          name: wheels-windows-${{ matrix.arch }}-py${{ matrix.python-version }}
           path: dist/*.whl
 
       - name: Run tests

--- a/JupiterMag/Con2020/_CFunctions.py
+++ b/JupiterMag/Con2020/_CFunctions.py
@@ -34,7 +34,7 @@ _CCon2020Field.argtypes = [
 ]  # Bx/Br output scalar
 
 # con2020 get parameters
-_CGetCon2020Params = libjupitermag.GetCon2020Params
+_CGetCon2020Params = libjupitermag.JupiterMagGetCon2020Params
 _CGetCon2020Params.restype = None
 _CGetCon2020Params.argtypes = [
     c_double_ptr,  # mui
@@ -62,7 +62,7 @@ _CGetCon2020Params.argtypes = [
     c_double_ptr,
 ]  # dthetaoc
 # con2020 set parameters
-_CSetCon2020Params = libjupitermag.SetCon2020Params
+_CSetCon2020Params = libjupitermag.JupiterMagSetCon2020Params
 _CSetCon2020Params.restype = None
 _CSetCon2020Params.argtypes = [
     c_double,  # mui

--- a/JupiterMag/Internal/_CFunctions.py
+++ b/JupiterMag/Internal/_CFunctions.py
@@ -38,11 +38,11 @@ _CInternalFieldDeg.argtypes = [
 
 
 # set internal config
-_CSetInternalCFG = libjupitermag.SetInternalCFG
+_CSetInternalCFG = libjupitermag.JupiterMagSetInternalCFG
 _CSetInternalCFG.restype = None
 _CSetInternalCFG.argtypes = [c_char_p, c_bool, c_bool, c_int]
 
 # get internal config
-_CGetInternalCFG = libjupitermag.GetInternalCFG
+_CGetInternalCFG = libjupitermag.JupiterMagGetInternalCFG
 _CGetInternalCFG.restype = None
 _CGetInternalCFG.argtypes = [c_char_p, c_bool_ptr, c_bool_ptr, c_int_ptr]

--- a/JupiterMag/__init__.py
+++ b/JupiterMag/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 
 from . import Globals
 from . import Con2020

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "JupiterMag"
-version = "1.5.0"
+version = "1.5.1"
 description = "Some magnetic field models for Jupiter"
 readme = "README.md"
 license = "GPL-3.0-or-later"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 dependencies = [
 	"numpy",
 	"matplotlib",
-	"DateTimeTools>=1.3.1",
+	"DateTimeTools>=1.3.3",
 	"RecarrayTools",
 	"PyFileIO",
 	"scipy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 dependencies = [
 	"numpy",
 	"matplotlib",
-	"DateTimeTools",
+	"DateTimeTools>=1.3.1",
 	"RecarrayTools",
 	"PyFileIO",
 	"scipy",


### PR DESCRIPTION
Added Windows on ARM build for JuptierMag. The build now uses MSVC, as getting MSYS2 to work in Windows ARM was a nightmare. MSVC was hell too - all submodules had to be modified in order to export the required symbols.